### PR TITLE
Pc/fix plot intermediate values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--settings-path, pyproject.toml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-optuna 0.10.2
+
+### Fixes
+- Fixed plot_intermeadiate_values() got unexpected keyword argument error ([#28](https://github.com/neptune-ai/neptune-optuna/pull/28))
+
 ## neptune-optuna 0.10.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## neptune-optuna 0.10.2
+## [UNRELEASED] neptune-optuna 0.10.2
 
 ### Fixes
 - Fixed plot_intermeadiate_values() got unexpected keyword argument error ([#28](https://github.com/neptune-ai/neptune-optuna/pull/28))

--- a/src/neptune_optuna/impl/__init__.py
+++ b/src/neptune_optuna/impl/__init__.py
@@ -574,7 +574,11 @@ def _log_plots(
                     vis.plot_slice(study, target=target, target_name=target_name)
                 )
 
-            if log_plot_intermediate_values and any(trial.intermediate_values for trial in study.trials):
+            if (
+                not _is_multi_objective(study=study)
+                and log_plot_intermediate_values
+                and any(trial.intermediate_values for trial in study.trials)
+            ):
                 # Intermediate values plot if available only if the above condition is met
                 temp_handle["plot_intermediate_values"] = neptune.types.File.as_html(
                     vis.plot_intermediate_values(study)

--- a/src/neptune_optuna/impl/__init__.py
+++ b/src/neptune_optuna/impl/__init__.py
@@ -574,12 +574,6 @@ def _log_plots(
                     vis.plot_slice(study, target=target, target_name=target_name)
                 )
 
-            if log_plot_intermediate_values and any(trial.intermediate_values for trial in study.trials):
-                # Intermediate values plot if available only if the above condition is met
-                temp_handle["plot_intermediate_values"] = neptune.types.File.as_html(
-                    vis.plot_intermediate_values(study, target=target, target_name=target_name)
-                )
-
             if log_plot_optimization_history:
                 temp_handle["plot_optimization_history"] = neptune.types.File.as_html(
                     vis.plot_optimization_history(study, target=target, target_name=target_name)
@@ -592,6 +586,16 @@ def _log_plots(
         and visualization_backend == "plotly"
     ):
         handle["plot_pareto_front"] = neptune.types.File.as_html(vis.plot_pareto_front(study, target_names=namespaces))
+
+    if (
+        vis.is_available
+        and log_plot_intermediate_values
+        and any(trial.intermediate_values for trial in study.trials)
+    ):
+        # Intermediate values plot if available only if the above condition is met
+        handle["plot_intermediate_values"] = neptune.types.File.as_html(
+            vis.plot_intermediate_values(study)
+        )
 
 
 def _log_single_trial(run, study: optuna.Study, trial: optuna.trial.FrozenTrial, namespaces, best=False):

--- a/src/neptune_optuna/impl/__init__.py
+++ b/src/neptune_optuna/impl/__init__.py
@@ -574,6 +574,12 @@ def _log_plots(
                     vis.plot_slice(study, target=target, target_name=target_name)
                 )
 
+            if log_plot_intermediate_values and any(trial.intermediate_values for trial in study.trials):
+                # Intermediate values plot if available only if the above condition is met
+                temp_handle["plot_intermediate_values"] = neptune.types.File.as_html(
+                    vis.plot_intermediate_values(study)
+                )
+
             if log_plot_optimization_history:
                 temp_handle["plot_optimization_history"] = neptune.types.File.as_html(
                     vis.plot_optimization_history(study, target=target, target_name=target_name)
@@ -586,16 +592,6 @@ def _log_plots(
         and visualization_backend == "plotly"
     ):
         handle["plot_pareto_front"] = neptune.types.File.as_html(vis.plot_pareto_front(study, target_names=namespaces))
-
-    if (
-        vis.is_available
-        and log_plot_intermediate_values
-        and any(trial.intermediate_values for trial in study.trials)
-    ):
-        # Intermediate values plot if available only if the above condition is met
-        handle["plot_intermediate_values"] = neptune.types.File.as_html(
-            vis.plot_intermediate_values(study)
-        )
 
 
 def _log_single_trial(run, study: optuna.Study, trial: optuna.trial.FrozenTrial, namespaces, best=False):


### PR DESCRIPTION
Closes #27 

**Note**:

The Optuna pruning feature is currently only available for single-objective optimation, which is required to use `plot_intermediate_values`.

An example use case for `plot_intermediate_values`: https://optuna.readthedocs.io/en/stable/_modules/optuna/visualization/_intermediate_values.html

In the case of a multi-objective optimization setting, it throws the following errors:

> NotImplementedError: Trial.should_prune is not supported for multi-objective optimization
> NotImplementedError: Trial.report is not supported for multi-objective optimization.

