### PR TITLE
Added `log_all_trials` param to `NeptuneCallback`

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: v2
+      uses: actions/checkout@v4
       with:
         repository: neptune-ai/neptune-optuna
         path: ${{ inputs.working_directory }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: v2
       with:
         repository: neptune-ai/neptune-optuna
         path: ${{ inputs.working_directory }}
@@ -21,7 +21,7 @@ runs:
       shell: bash
 
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v2
       with:
         ubuntu-skip-apt-update: true
         macos-skip-brew-update: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -25,9 +25,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-optuna 1.1.1
+
+### Features
+- Added `log_all_trials` flag in `NeptuneCallback` ([#41](https://github.com/neptune-ai/neptune-optuna/pull/41))
+
 ## neptune-optuna 1.1.0
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## neptune-optuna 1.1.1
+## neptune-optuna 1.2.0
 
 ### Features
 - Added `log_all_trials` flag in `NeptuneCallback` ([#41](https://github.com/neptune-ai/neptune-optuna/pull/41))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neptune + Optuna integration
 
-Neptune is a lightweight experiment tracker that offers a single place to track, compare, store, and collaborate on experiments and models. 
+Neptune is a lightweight experiment tracker that offers a single place to track, compare, store, and collaborate on experiments and models.
 
 This integration lets you use it as an Optuna visualization dashboard to log and monitor hyperparameter sweeps live.
 
@@ -21,7 +21,7 @@ This integration lets you use it as an Optuna visualization dashboard to log and
 
 * [Documentation](https://docs.neptune.ai/integrations/optuna)
 * [Code example on GitHub](https://github.com/neptune-ai/examples/blob/main/integrations-and-supported-tools/optuna/scripts)
-* [Run logged in the Neptune app](https://app.neptune.ai/o/common/org/optuna-integration/runs/details?viewId=b6190a29-91be-4e64-880a-8f6085a6bb78&detailsTab=dashboard&dashboardId=Vizualizations-5ea92658-6a56-4656-b225-e81c6fbfc8ab&shortId=NEP1-13880&type=run)
+* [Run logged in the Neptune app](https://app.neptune.ai/o/common/org/optuna-integration/runs/details?viewId=b6190a29-91be-4e64-880a-8f6085a6bb78&detailsTab=dashboard&dashboardId=Vizualizations-5ea92658-6a56-4656-b225-e81c6fbfc8ab&shortId=NEP1-18517&type=run)
 * [Run example in Google Colab](https://colab.research.google.com/github/neptune-ai/examples/blob/master/integrations-and-supported-tools/optuna/notebooks/Neptune_Optuna_integration.ipynb)
 
 ## Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest-cov",
     "deepdiff",
     "neptune",
+    "cffi",
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
 deepdiff = { version = ">=6.2.3", optional = true }
 neptune = { version = ">=1.0.0", optional = true }
+cffi = { version = "*", optional = true}
 
 [tool.poetry.extras]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ scikit-learn = "*"
 pre-commit = { version = "*", optional = true }
 pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
-deepdiff = { version = ">=6.2.3", optional = true }
+deepdiff = { version = ">=6.2.3, <6.7", optional = true }
 neptune = { version = ">=1.0.0", optional = true }
 cffi = { version = "*", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ scikit-learn = "*"
 pre-commit = { version = "*", optional = true }
 pytest = { version = ">=5.0", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
-deepdiff = { version = ">=6.2.3, <6.7", optional = true }
+deepdiff = { version = "6.2.3", optional = true }
 neptune = { version = ">=1.0.0", optional = true }
 cffi = { version = "*", optional = true}
 

--- a/src/neptune_optuna/impl/__init__.py
+++ b/src/neptune_optuna/impl/__init__.py
@@ -95,6 +95,7 @@ class NeptuneCallback:
         log_plot_optimization_history: If True, the optuna.visualizations.plot_optimization_history
             visualization will be logged to Neptune.
         target_names: List of one or more study objective names to log (see example).
+        log_all_trials: If True, all trials are logged. Defaults to True.
 
     Examples:
         Create a run:
@@ -136,6 +137,7 @@ class NeptuneCallback:
         log_plot_intermediate_values: bool = True,
         log_plot_optimization_history: bool = True,
         target_names: Optional[List[str]] = None,
+        log_all_trials: bool = True,
     ):
 
         expect_not_an_experiment(run)
@@ -165,6 +167,7 @@ class NeptuneCallback:
             (bool, type(None)),
         )
         verify_type("target_names", target_names, (list, type(None)))
+        verify_type("log_all_trials", log_all_trials, (bool, type(None)))
 
         if base_namespace != "":
             self.run = run[base_namespace]
@@ -183,6 +186,7 @@ class NeptuneCallback:
         self._log_plot_intermediate_values = log_plot_intermediate_values
         self._log_plot_optimization_history = log_plot_optimization_history
         self._target_names = target_names
+        self._log_all_trials = log_all_trials
         self._namespaces = None
 
         root_obj = self.run
@@ -194,7 +198,9 @@ class NeptuneCallback:
     def __call__(self, study: optuna.Study, trial: optuna.trial.FrozenTrial):
         if self._namespaces is None:
             self._namespaces = _get_namespaces(study, self._target_names)
-        self._log_trial(study, trial)
+
+        if self._log_all_trials:
+            self._log_trial(study, trial)
         self._log_trial_distributions(trial)
         self._log_best_trials(study)
         self._log_study_details(study, trial)

--- a/src/neptune_optuna/impl/__init__.py
+++ b/src/neptune_optuna/impl/__init__.py
@@ -167,7 +167,7 @@ class NeptuneCallback:
             (bool, type(None)),
         )
         verify_type("target_names", target_names, (list, type(None)))
-        verify_type("log_all_trials", log_all_trials, (bool, type(None)))
+        verify_type("log_all_trials", log_all_trials, bool)
 
         if base_namespace != "":
             self.run = run[base_namespace]


### PR DESCRIPTION
Added a `log_all_trials` param to `NeptuneCallback` to allow disabling logging of all trials, similar to what `log_all_trials` does in `log_study_metadata()`