### PR TITLE
Set target name in single objective studies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## neptune-optuna 1.5.0
+
+### Features
+- Extended `target_names` support for single-objective studies ([#55](https://github.com/neptune-ai/neptune-optuna/pull/55))
+
 ## neptune-optuna 1.4.1
 
 ### Fixes

--- a/src/neptune_optuna/impl/__init__.py
+++ b/src/neptune_optuna/impl/__init__.py
@@ -291,7 +291,7 @@ def _get_namespaces(study: optuna.Study, target_names: Optional[List[str]] = Non
 
     else:
         if target_names is None:
-            return "objective_value"
+            return "value"
 
         assert len(target_names) == len(
             [study.direction]
@@ -612,17 +612,17 @@ def _log_single_trial(run, study: optuna.Study, trial: optuna.trial.FrozenTrial,
             handle["params"].append(stringify_unsupported(trial.params))
             for k, v in enumerate(trial.values):
                 handle[f"values/{namespaces[k]}"].append(stringify_unsupported(v), step=trial._number)
-
     else:
-        handle[f"trials/{trial._number}/value"] = stringify_unsupported(trial.value)
+        handle[f"trials/{trial._number}/{namespaces}"] = stringify_unsupported(trial.value)
         if best:
-            handle["value"] = stringify_unsupported(trial.value)
+            handle[namespaces] = stringify_unsupported(trial.value)
             handle["params"] = stringify_unsupported(trial.params)
-            handle["value|params"] = f"value: {trial.value}| params: {trial.params}"
+            handle[f"{namespaces}|params"] = f"{namespaces}: {trial.value}| params: {trial.params}"
         else:
-            handle["values"].append(stringify_unsupported(trial.value), step=trial._number)
+            value_key = "values" if namespaces == "value" else namespaces  # For backward compatibility
+            handle[f"{value_key}"].append(stringify_unsupported(trial.value), step=trial._number)
             handle["params"].append(stringify_unsupported(trial.params))
-            handle["values|params"].append(f"value: {trial.value}| params: {trial.params}")
+            handle[f"{value_key}|params"].append(f"{value_key}: {trial.value}| params: {trial.params}")
 
     if trial.state.is_finished() and trial.state != optuna.trial.TrialState.COMPLETE:
         handle[f"trials/{trial._number}/state"] = repr(trial.state)


### PR DESCRIPTION
Expended support for `target_names` in single-objective studies.

Single objective studies now take the first element of the `target_names` list to use as the name of the target when logging to Neptune. If `target_names` is not passed, the name defaults to `value`.

Previously, `target_names` was ignored for single-objective studies.